### PR TITLE
Ensure User Names are Unique

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -31,18 +31,70 @@ Params = {
 }
 ```
 
+### deleteUser
+
 ## Movie Clubs
 
 ### createMovieClub
 
+```
+Params = {
+  ownerId: "string",
+  ownerName: "string",
+  name: "string",
+  isPublic: boolean,
+  timeInterval: "string",
+  bannerUrl: "string/path"
+}
+```
+
 ### updateMovieClub
+
+```
+Params = {
+  movieClubId: "string",
+  ownerId: "string",
+  ownerName?: "string",
+  name?: "string",
+  isPublic?: boolean,
+  timeInterval?: "string",
+  bannerUrl?: "string/path"
+}
+```
+
+### deleteMovieClub
 
 ## Movies
 
 ### suggestMovie
 
+### rotateMovie
+
 ## Comments
 
 ### postComment
 
+```
+Params = {
+  movieClubId: "string",
+  movieId: "string",
+  text: "string",
+  userId: "string",
+  username: boolean
+}
+
+Returns:
+200 - "commentId"
+```
+
 ### deleteComment
+
+```
+Params = {
+  movieClubId: "string",
+  movieId: "string",
+  commentId: "string",
+}
+
+Returns:
+200 - "commentId"

--- a/functions/README.md
+++ b/functions/README.md
@@ -2,16 +2,31 @@
 
 ## Users
 
-### createUser
+### createUserWithEmail
 
 ```
 Params = {
   email: "string@email.com",
   name: "string",
-  password?: "string",
+  password: "string",
   bio?: "string",
-  image?: "string/path",
-  signInProvider?: "string"
+  image?: "string/path"
+}
+
+Returns: 
+200 - "uid string"
+400 - code: "invalid-argument"
+```
+
+### createUserWithSignInProvider
+
+```
+Params = {
+  email: "string@email.com",
+  name: "string",
+  signInProvider: "string",
+  bio?: "string",
+  image?: "string/path"
 }
 
 Returns: 

--- a/functions/README.md
+++ b/functions/README.md
@@ -38,13 +38,14 @@ Returns:
 
 ```
 Params = {
-  email?: "string@email.com",
   name?: "string",
   bio?: "string",
   image?: "string/path",
   signInProvider?: "string"
 }
 ```
+
+### updateUserEmail
 
 ### deleteUser
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -1,0 +1,48 @@
+# Functions
+
+## Users
+
+### createUser
+
+```
+Params = {
+  email: "string@email.com",
+  name: "string",
+  password?: "string",
+  bio?: "string",
+  image?: "string/path",
+  signInProvider?: "string"
+}
+
+Returns: 
+200 - "uid string"
+400 - code: "invalid-argument"
+```
+
+### updateUser
+
+```
+Params = {
+  email?: "string@email.com",
+  name?: "string",
+  bio?: "string",
+  image?: "string/path",
+  signInProvider?: "string"
+}
+```
+
+## Movie Clubs
+
+### createMovieClub
+
+### updateMovieClub
+
+## Movies
+
+### suggestMovie
+
+## Comments
+
+### postComment
+
+### deleteComment

--- a/functions/src/movieClubs/movieClubFunctions.js
+++ b/functions/src/movieClubs/movieClubFunctions.js
@@ -20,9 +20,11 @@ exports.createMovieClub = functions.https.onCall(async (data, context) => {
       bannerUrl: data.bannerUrl
     };
 
-    await movieClubRef.add(movieClubData);
+    const movieClub = await movieClubRef.add(movieClubData);
 
     logVerbose("Movie Club created successfully!");
+
+    return movieClub;
   } catch (error) {
     handleCatchHttpsError("Error creating Movie Club:", error)
   };

--- a/functions/src/movieClubs/movieClubFunctions.js
+++ b/functions/src/movieClubs/movieClubFunctions.js
@@ -20,11 +20,9 @@ exports.createMovieClub = functions.https.onCall(async (data, context) => {
       bannerUrl: data.bannerUrl
     };
 
-    const movieClub = await movieClubRef.add(movieClubData);
+    await movieClubRef.add(movieClubData);
 
     logVerbose("Movie Club created successfully!");
-
-    return movieClub;
   } catch (error) {
     handleCatchHttpsError("Error creating Movie Club:", error)
   };

--- a/functions/src/users/userFunctions.js
+++ b/functions/src/users/userFunctions.js
@@ -146,10 +146,8 @@ exports.updateUser = functions.https.onCall(async (data, context) => {
 
     const userData = {
       ...(data.bio && { bio: data.bio }),
-      ...(data.email && { email: data.email }),
       ...(data.image && { image: data.image }),
-      ...(data.name && { name: data.name }),
-      ...(data.signInProvider && { signInProvider: data.signInProvider }),
+      ...(data.name && { name: data.name })
     };
 
     await db.collection("users").doc(data.id).update(userData);

--- a/functions/test/src/movieClubs/movies/comments/commentFunctions.test.js
+++ b/functions/test/src/movieClubs/movies/comments/commentFunctions.test.js
@@ -6,7 +6,7 @@ const { db } = require("firestore");
 const { populateUserData, populateMovieClubData, populateMovieData } = require("mocks");
 const { comments: { deleteComment, postComment } } = require("index");
 
-describe("comment functions", () => {
+describe("Comment Functions", () => {
   const postWrapped = test.wrap(postComment);
   const deleteWrapped = test.wrap(deleteComment);
 

--- a/functions/test/src/users/userFunctions.test.js
+++ b/functions/test/src/users/userFunctions.test.js
@@ -186,8 +186,7 @@ describe("User Functions", () => {
         id: user.id,
         name: "Updated test User",
         image: "Updated test Image",
-        bio: "Updated test Bio",
-        email: "updatedTest@email.com"
+        bio: "Updated test Bio"
       };
     });
 
@@ -200,7 +199,6 @@ describe("User Functions", () => {
       assert(userDoc.name == userData.name);
       assert(userDoc.image == userData.image);
       assert(userDoc.bio == userData.bio);
-      assert(userDoc.email == userData.email);
     });
 
     it("should error without required fields", async () => {

--- a/functions/test/src/users/userFunctions.test.js
+++ b/functions/test/src/users/userFunctions.test.js
@@ -2,96 +2,127 @@
 
 const assert = require("assert");
 const { test } = require("test/testHelper");
-const { db } = require("firestore");
+const { db, admin } = require("firestore");
 const { populateUserData } = require("mocks");
 const { users: { createUser, updateUser } } = require("index");
 
-describe("createUser", () => {
-  const wrapped = test.wrap(createUser);
+describe("User Functions", () => {
+  describe("createUser", () => {
+    const createUserWrapped = test.wrap(createUser);
 
-  let userId;
-  let userData;
+    let userId;
+    let userData;
 
-  beforeEach(async () => {
-    userData = {
-      name: "Test User",
-      image: "Test Image",
-      bio: "Test Bio",
-      email: "test@email.com",
-      signInProvider: "apple"
-    };
+    beforeEach(async () => {
+      userData = {
+        name: "Test User",
+        image: "Test Image",
+        bio: "Test Bio",
+        email: "test@email.com",
+        signInProvider: "apple"
+      };
+    });
+
+    afterEach(async () => {
+      const result = await admin.auth().listUsers();
+      const users = result.users.map(user => user.uid);
+
+      await admin.auth().deleteUsers(users);
+    });
+
+    it("should create a new User when email exists in auth via alt sign-in (ie apple/gmail)", async () => {
+      userId = await createUserWrapped(userData);
+
+      const snap = await db.collection("users").doc(userId).get();
+      const userDoc = snap.data();
+
+      assert(userDoc.name == userData.name);
+      assert(userDoc.image == userData.image);
+      assert(userDoc.bio == userData.bio);
+      assert(userDoc.email == userData.email);
+    });
+
+    it("should create a new User when email doesn't exist in auth", async () => {
+      userId = await createUserWrapped(userData);
+
+      const snap = await db.collection("users").doc(userId).get();
+      const userDoc = snap.data();
+
+      assert(userDoc.name == userData.name);
+      assert(userDoc.image == userData.image);
+      assert(userDoc.bio == userData.bio);
+      assert(userDoc.email == userData.email);
+    });
+
+    it("should error when email already exists", async () => {
+      try {
+        await createUserWrapped(userData);
+        await createUserWrapped({ email: userData.email, name: "Test User 2" });
+
+        assert.fail("Expected error not thrown");
+      } catch (error) {
+        assert.match(error.message, /The email address is already in use by another account./);
+      };
+    });
+
+    it("should error when user name already exists", async () => {
+      try {
+        await createUserWrapped(userData);
+        await createUserWrapped({ email: "test2@email.com", name: userData.name });
+
+        assert.fail("Expected error not thrown");
+      } catch (error) {
+        assert.match(error.message, /name Test User already exists./);
+      };
+    });
+
+    it("should error without required fields", async () => {
+      try {
+        await createUserWrapped({})
+        assert.fail("Expected error not thrown");
+      } catch (error) {
+        assert.match(error.message, /The function must be called with email, name./);
+      };
+    });
   });
 
-  it("should create a new User when email exists in auth via alt sign-in (ie apple/gmail)", async () => {
-    userId = await wrapped(userData);
+  describe("updateUser", () => {
+    const updateUserWrapped = test.wrap(updateUser);
 
-    const snap = await db.collection("users").doc(userId).get();
-    const userDoc = snap.data();
+    let user;
+    let userData;
 
-    assert(userDoc.name == userData.name);
-    assert(userDoc.image == userData.image);
-    assert(userDoc.bio == userData.bio);
-    assert(userDoc.email == userData.email);
-  });
+    beforeEach(async () => {
+      user = await populateUserData();
 
-  it("should create a new User when email doesn't exist in auth", async () => {
-    userId = await wrapped(userData);
+      userData = {
+        id: user.id,
+        name: "Updated test User",
+        image: "Updated test Image",
+        bio: "Updated test Bio",
+        email: "updatedTest@email.com"
+      };
+    });
 
-    const snap = await db.collection("users").doc(userId).get();
-    const userDoc = snap.data();
+    it("should update an existing User", async () => {
+      await updateUserWrapped(userData);
+      const snap = await db.collection("users").doc(user.id).get();
+      const userDoc = snap.data();
 
-    assert(userDoc.name == userData.name);
-    assert(userDoc.image == userData.image);
-    assert(userDoc.bio == userData.bio);
-    assert(userDoc.email == userData.email);
-  });
+      assert(userDoc.id == userData.id);
+      assert(userDoc.name == userData.name);
+      assert(userDoc.image == userData.image);
+      assert(userDoc.bio == userData.bio);
+      assert(userDoc.email == userData.email);
+    });
 
-  it("should error without required fields", async () => {
-    try {
-      await wrapped({})
-      assert.fail("Expected error not thrown");
-    } catch (error) {
-      assert.match(error.message, /The function must be called with email, name./);
-    };
-  });
-});
-
-describe("updateUser", () => {
-  const wrapped = test.wrap(updateUser);
-
-  let user;
-  let userData;
-
-  beforeEach(async () => {
-    user = await populateUserData();
-
-    userData = {
-      id: user.id,
-      name: "Updated test User",
-      image: "Updated test Image",
-      bio: "Updated test Bio",
-      email: "updatedTest@email.com"
-    };
-  });
-
-  it("should update an existing User", async () => {
-    await wrapped(userData);
-    const snap = await db.collection("users").doc(user.id).get();
-    const userDoc = snap.data();
-
-    assert(userDoc.id == userData.id);
-    assert(userDoc.name == userData.name);
-    assert(userDoc.image == userData.image);
-    assert(userDoc.bio == userData.bio);
-    assert(userDoc.email == userData.email);
-  });
-
-  it("should error without required fields", async () => {
-    try {
-      await wrapped({})
-      assert.fail("Expected error not thrown");
-    } catch (error) {
-      assert.match(error.message, /The function must be called with id./);
-    };
+    it("should error without required fields", async () => {
+      try {
+        await updateUserWrapped({})
+        assert.fail("Expected error not thrown");
+      } catch (error) {
+        assert.match(error.message, /The function must be called with id./);
+      };
+    });
   });
 });


### PR DESCRIPTION
closes #23 

Separates the create user routes into one using email/password and one using a sign in provider.
Makes sure user names and emails are unique by implementing a Firebase transaction that checks to see if a user already exists with that name or email. 

Also fixes a bug where trying to use an existing email would overwrite an existing user instead of failing.
Also adds the start of a README file for an overview of available functions and their parameters.

Questions:
-Are there any other fields that need to be unique? Movie Club names maybe?
-Is there some sort of session token or jwt we can use to verify identity and pass along with requests? (maybe this is relevant? https://firebase.google.com/docs/auth/admin/verify-id-tokens)
-Should we use the username as the document id instead of the uid from Auth?
-Are there any other fields that need to be unique? Movie Club names maybe?