### PR TITLE
Update to firebase-functions version 6

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,8 +8,7 @@
       "dependencies": {
         "dotenv": "^16.4.5",
         "firebase-admin": "^12.4.0",
-        "firebase-functions": "^5.1.1",
-        "firebase-tools": "^13.16.0",
+        "firebase-functions": "^6.0.1",
         "module-alias": "^2.2.3"
       },
       "devDependencies": {
@@ -6044,9 +6043,10 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-5.1.1.tgz",
-      "integrity": "sha512-KkyKZE98Leg/C73oRyuUYox04PQeeBThdygMfeX+7t1cmKWYKa/ZieYa89U8GHgED+0mF7m7wfNZOfbURYxIKg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.0.1.tgz",
+      "integrity": "sha512-0rIpTU6dnLRvP3IK+okn1FDjoqjzShm0/S+i4OMY7JFu/HJoyJ1JNkrT4KjECy1/mCHK49KsmH8iYE0rzrglHg==",
+      "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",

--- a/functions/package.json
+++ b/functions/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "firebase-admin": "^12.4.0",
-    "firebase-functions": "^5.1.1",
+    "firebase-functions": "^6.0.1",
     "module-alias": "^2.2.3"
   },
   "devDependencies": {

--- a/functions/src/movieClubs/movieClubFunctions.ts
+++ b/functions/src/movieClubs/movieClubFunctions.ts
@@ -2,24 +2,25 @@ import * as functions from "firebase-functions";
 import { firestore } from "firestore";
 import { handleCatchHttpsError, logVerbose, verifyRequiredFields } from "helpers";
 import { MovieClubData, UpdateMovieClubData } from "./movieClubTypes";
+import { CallableRequest } from "firebase-functions/https";
 
-exports.createMovieClub = functions.https.onCall(async (data: MovieClubData, context) => {
+exports.createMovieClub = functions.https.onCall(async (request: CallableRequest<MovieClubData>) => {
   try {
     const requiredFields = ["bannerUrl", "description", "image", "isPublic", "name", "ownerId", "ownerName", "timeInterval"];
-    verifyRequiredFields(data, requiredFields);
+    verifyRequiredFields(request.data, requiredFields);
 
     const movieClubRef = firestore.collection("movieclubs");
 
     const movieClubData: MovieClubData = {
-      bannerUrl: data.bannerUrl,
-      description: data.description,
-      image: data.image,
-      isPublic: data.isPublic,
-      name: data.name,
+      bannerUrl: request.data.bannerUrl,
+      description: request.data.description,
+      image: request.data.image,
+      isPublic: request.data.isPublic,
+      name: request.data.name,
       numMembers: 1,
-      ownerId: data.ownerId,
-      ownerName: data.ownerName,
-      timeInterval: data.timeInterval,
+      ownerId: request.data.ownerId,
+      ownerName: request.data.ownerName,
+      timeInterval: request.data.timeInterval,
       createdAt: Date.now()
     };
 
@@ -33,26 +34,26 @@ exports.createMovieClub = functions.https.onCall(async (data: MovieClubData, con
   };
 });
 
-exports.updateMovieClub = functions.https.onCall(async (data: UpdateMovieClubData, context) => {
+exports.updateMovieClub = functions.https.onCall(async (request: CallableRequest<UpdateMovieClubData>) => {
   try {
     const requiredFields = ["id"];
-    verifyRequiredFields(data, requiredFields);
+    verifyRequiredFields(request.data, requiredFields);
 
-    const movieClubRef = firestore.collection("movieclubs").doc(data.id);
+    const movieClubRef = firestore.collection("movieclubs").doc(request.data.id);
 
     const movieClubData = {
-      ...(data.bannerUrl && { bannerUrl: data.bannerUrl }),
-      ...(data.description && { description: data.description }),
-      ...(data.image && { image: data.image }),
-      ...(data.isPublic != undefined && { isPublic: data.isPublic }),
-      ...(data.name && { name: data.name }),
-      ...(data.timeInterval && { timeInterval: data.timeInterval })
+      ...(request.data.bannerUrl && { bannerUrl: request.data.bannerUrl }),
+      ...(request.data.description && { description: request.data.description }),
+      ...(request.data.image && { image: request.data.image }),
+      ...(request.data.isPublic != undefined && { isPublic: request.data.isPublic }),
+      ...(request.data.name && { name: request.data.name }),
+      ...(request.data.timeInterval && { timeInterval: request.data.timeInterval })
     };
 
     await movieClubRef.update(movieClubData);
 
     logVerbose("Movie Club updated successfully!");
   } catch (error) {
-    handleCatchHttpsError(`Error updating Movie Club ${data.id}:`, error)
+    handleCatchHttpsError(`Error updating Movie Club ${request.data.id}:`, error)
   };
 });

--- a/functions/src/movieClubs/movies/comments/commentFunctions.ts
+++ b/functions/src/movieClubs/movies/comments/commentFunctions.ts
@@ -2,25 +2,26 @@ import * as functions from "firebase-functions";
 import { firestore } from "firestore";
 import { handleCatchHttpsError, logVerbose, verifyRequiredFields } from "helpers";
 import { DeleteCommentData, PostCommentData } from "./commentTypes";
+import { CallableRequest } from "firebase-functions/https";
 
-exports.postComment = functions.https.onCall(async (data: PostCommentData, context) => {
+exports.postComment = functions.https.onCall(async (request: CallableRequest<PostCommentData>) => {
   try {
     const requiredFields = ["movieClubId", "movieId", "text", "userId", "username"]
-    verifyRequiredFields(data, requiredFields)
+    verifyRequiredFields(request.data, requiredFields)
 
     const commentsRef = firestore
       .collection("movieclubs")
-      .doc(data.movieClubId)
+      .doc(request.data.movieClubId)
       .collection("movies")
-      .doc(data.movieId)
+      .doc(request.data.movieId)
       .collection("comments");
 
     const commentData = {
-      userId: data.userId,
-      username: data.username,
-      text: data.text,
+      userId: request.data.userId,
+      username: request.data.username,
+      text: request.data.text,
       likes: 0,
-      image: data.image || "",
+      image: request.data.image || "",
       createdAt: Date.now()
     }
 
@@ -34,18 +35,18 @@ exports.postComment = functions.https.onCall(async (data: PostCommentData, conte
   }
 });
 
-exports.deleteComment = functions.https.onCall(async (data: DeleteCommentData, context) => {
+exports.deleteComment = functions.https.onCall(async (request: CallableRequest<DeleteCommentData>) => {
   try {
     const requiredFields = ["id", "movieClubId", "movieId"];
-    verifyRequiredFields(data, requiredFields);
+    verifyRequiredFields(request.data, requiredFields);
 
     const commentRef = firestore
       .collection("movieclubs")
-      .doc(data.movieClubId)
+      .doc(request.data.movieClubId)
       .collection("movies")
-      .doc(data.movieId)
+      .doc(request.data.movieId)
       .collection("comments")
-      .doc(data.id);
+      .doc(request.data.id);
 
     // Delete the comment
     await commentRef.delete();

--- a/functions/src/movieClubs/movies/movieFunctions.js
+++ b/functions/src/movieClubs/movies/movieFunctions.js
@@ -3,10 +3,10 @@ const fetch = require("node-fetch");
 const { firestore } = require("firestore");
 
 // Export the scheduled function for deployment
-exports.rotateMovie = functions.pubsub.schedule('every 24 hours').onRun(async () => {
-  console.log('Rotating movie...');
-  await rotateMovieLogic();
-});
+// exports.rotateMovie = functions.pubsub.schedule('every 24 hours').onRun(async () => {
+//   console.log('Rotating movie...');
+//   await rotateMovieLogic();
+// });
 
 async function rotateMovieLogic() {
   const currentTimestamp = new Date();
@@ -70,4 +70,4 @@ async function processMovieClub(movieclubDoc, futureDate, apiEndpoint) {
 
 exports.rotateMovieLogic = rotateMovieLogic;
 
-exports.rotateMovie = functions.pubsub.schedule('every 24 hours').onRun(rotateMovieLogic);
+// exports.rotateMovie = functions.pubsub.schedule('every 24 hours').onRun(rotateMovieLogic);

--- a/functions/test/src/movieClubs/movieClubFunctions.test.ts
+++ b/functions/test/src/movieClubs/movieClubFunctions.test.ts
@@ -37,7 +37,7 @@ describe("createMovieClub", () => {
   });
 
   it("should create a new Movie Club", async () => {
-    movieClub = await wrapped(movieClubData)
+    movieClub = await wrapped({ data: movieClubData })
     const snap = await firestore.collection("movieclubs").doc(movieClub.id).get()
     const movieClubDoc = snap.data();
 
@@ -54,7 +54,7 @@ describe("createMovieClub", () => {
 
   it("should error without required fields", async () => {
     try {
-      await wrapped({})
+      await wrapped({ data: {} })
       assert.fail('Expected error not thrown');
     } catch (error: any) {
       assert.match(error.message, /The function must be called with bannerUrl, description, image, isPublic, name, ownerId, ownerName, timeInterval./);
@@ -88,7 +88,7 @@ describe("updateMovieClub", () => {
   });
 
   it("should update an existing Movie Club", async () => {
-    await wrapped(movieClubData)
+    await wrapped({ data: movieClubData })
     const snap = await firestore.collection("movieclubs").doc(movieClub.id).get()
     const movieClubDoc = snap.data();
 
@@ -105,7 +105,7 @@ describe("updateMovieClub", () => {
 
   it("should error without required fields", async () => {
     try {
-      await wrapped({})
+      await wrapped({ data: {} })
       assert.fail('Expected error not thrown');
     } catch (error: any) {
       assert.match(error.message, /The function must be called with id/);
@@ -115,9 +115,11 @@ describe("updateMovieClub", () => {
   it.skip("should not allow a user who does not own the movie club to update it", async () => {
     try {
       await wrapped({
-        movieClubId: movieClub.id,
-        name: "Updated Test Club",
-        ownerId: "wrong-user-id",
+        data: {
+          movieClubId: movieClub.id,
+          name: "Updated Test Club",
+          ownerId: "wrong-user-id",
+        }
       })
       assert.fail('Expected error not thrown');
     } catch (error: any) {

--- a/functions/test/src/movieClubs/movies/comments/commentFunctions.test.ts
+++ b/functions/test/src/movieClubs/movies/comments/commentFunctions.test.ts
@@ -41,7 +41,7 @@ describe("Comment Functions", () => {
     });
 
     it("should create a new comment", async () => {
-      await postWrapped(commentData);
+      await postWrapped({ data: commentData });
 
       const snap = await firestore
         .collection("movieclubs")
@@ -62,7 +62,7 @@ describe("Comment Functions", () => {
 
     it("should error without required fields", async () => {
       try {
-        await postWrapped({});
+        await postWrapped({ data: {} });
         assert.fail("Expected error not thrown");
       } catch (error: any) {
         assert.match(error.message, /The function must be called with movieClubId, movieId, text, userId, username./);
@@ -99,7 +99,7 @@ describe("Comment Functions", () => {
 
       assert.equal(snap.data()?.id, commentData.id);
 
-      await deleteWrapped(commentData);
+      await deleteWrapped({ data: commentData });
 
       snap = await firestore
         .collection("movieclubs")
@@ -115,7 +115,7 @@ describe("Comment Functions", () => {
 
     it("should error without required fields", async () => {
       try {
-        await deleteWrapped({});
+        await deleteWrapped({ data: {} });
         assert.fail("Expected error not thrown");
       } catch (error: any) {
         assert.match(error.message, /The function must be called with id, movieClubId, movieId/);

--- a/functions/test/src/users/userFunctions.test.ts
+++ b/functions/test/src/users/userFunctions.test.ts
@@ -34,7 +34,7 @@ describe("User Functions", () => {
     });
 
     it("should create a new User with email, name and password", async () => {
-      userId = await createUserWithEmailWrapped(userData);
+      userId = await createUserWithEmailWrapped({ data: userData });
 
       const snap = await firestore.collection("users").doc(userId).get();
       const userDoc = snap.data();
@@ -47,10 +47,10 @@ describe("User Functions", () => {
 
     it("should error when email already exists", async () => {
       try {
-        await createUserWithEmailWrapped(userData);
+        await createUserWithEmailWrapped({ data: userData });
 
         userData.name = "Test User 2";
-        await createUserWithEmailWrapped(userData);
+        await createUserWithEmailWrapped({ data: userData });
 
         assert.fail("Expected error not thrown");
       } catch (error: any) {
@@ -60,10 +60,10 @@ describe("User Functions", () => {
 
     it("should error when user name already exists", async () => {
       try {
-        await createUserWithEmailWrapped(userData);
+        await createUserWithEmailWrapped({ data: userData });
 
         userData.email = "test2@email.com";
-        await createUserWithEmailWrapped(userData);
+        await createUserWithEmailWrapped({ data: userData });
 
         assert.fail("Expected error not thrown");
       } catch (error: any) {
@@ -73,7 +73,7 @@ describe("User Functions", () => {
 
     it("should error without required fields", async () => {
       try {
-        await createUserWithEmailWrapped({})
+        await createUserWithEmailWrapped({ data: {} })
         assert.fail("Expected error not thrown");
       } catch (error: any) {
         assert.match(error.message, /The function must be called with email, name, password./);
@@ -110,7 +110,7 @@ describe("User Functions", () => {
     });
 
     it("should create a new User when email exists in auth via alt sign-in (ie apple/gmail)", async () => {
-      userId = await createUserWithSignInProviderWrapped(userData);
+      userId = await createUserWithSignInProviderWrapped({ data: userData });
 
       const snap = await firestore.collection("users").doc(userId).get();
       const userDoc = snap.data();
@@ -124,7 +124,7 @@ describe("User Functions", () => {
     it("should error when email doesn't exist in auth", async () => {
       try {
         userData.email = "nonexistant@email.com"
-        await createUserWithSignInProviderWrapped(userData);
+        await createUserWithSignInProviderWrapped({ data: userData });
 
         assert.fail("Expected error not thrown");
       } catch (error: any) {
@@ -134,10 +134,10 @@ describe("User Functions", () => {
 
     it("should error when email already exists", async () => {
       try {
-        await createUserWithSignInProviderWrapped(userData);
+        await createUserWithSignInProviderWrapped({ data: userData });
 
         userData.name = "Test User 2";
-        await createUserWithSignInProviderWrapped(userData);
+        await createUserWithSignInProviderWrapped({ data: userData });
 
         assert.fail("Expected error not thrown");
       } catch (error: any) {
@@ -147,7 +147,7 @@ describe("User Functions", () => {
 
     it("should error when user name already exists", async () => {
       try {
-        await createUserWithSignInProviderWrapped(userData);
+        await createUserWithSignInProviderWrapped({ data: userData });
 
         userData.email = "test2@email.com";
 
@@ -156,7 +156,7 @@ describe("User Functions", () => {
           displayName: userData.name
         });
 
-        await createUserWithSignInProviderWrapped(userData);
+        await createUserWithSignInProviderWrapped({ data: userData });
 
         assert.fail("Expected error not thrown");
       } catch (error: any) {
@@ -166,7 +166,7 @@ describe("User Functions", () => {
 
     it("should error without required fields", async () => {
       try {
-        await createUserWithSignInProviderWrapped({})
+        await createUserWithSignInProviderWrapped({ data: {} })
         assert.fail("Expected error not thrown");
       } catch (error: any) {
         assert.match(error.message, /The function must be called with email, name./);
@@ -192,7 +192,7 @@ describe("User Functions", () => {
     });
 
     it("should update an existing User", async () => {
-      await updateUserWrapped(userData);
+      await updateUserWrapped({ data: userData });
       const userId = user.id || "";
       const snap = await firestore.collection("users").doc(userId).get();
       const userDoc = snap.data();
@@ -205,7 +205,7 @@ describe("User Functions", () => {
 
     it("should error without required fields", async () => {
       try {
-        await updateUserWrapped({})
+        await updateUserWrapped({ data: {} })
         assert.fail("Expected error not thrown");
       } catch (error: any) {
         assert.match(error.message, /The function must be called with id./);


### PR DESCRIPTION
closes #31 

Replaces OnCall parameters with a `request` object instead of `data, context`.
In preparation for using `request.auth`.
Gives us a better type for a request.