### PR TITLE
Create and Delete Movie Club Suggestions

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -1,8 +1,9 @@
 # Project Setup
 
 ### Dependencies
-- Firebase CLI: https://firebase.google.com/docs/cli
 - Node: https://nodejs.org/en/download/package-manager
+- Firebase CLI: https://firebase.google.com/docs/cli
+`npm install -g firebase-tools`
 - Typescript: https://www.typescriptlang.org/download/
 
 ### Configure Firebase CLI

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -1,5 +1,5 @@
 require("module-alias/register");
 
-import { comments, config, movies, movieClubs, users } from "./src";
+import { comments, config, suggestions, movieClubs, users } from "./src";
 
-export { comments, config, movies, movieClubs, users };
+export { comments, config, suggestions, movieClubs, users };

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,8 +1,9 @@
 import * as config from "../config";
 
 import * as comments from "./movieClubs/movies/comments/commentFunctions";
-import * as movies from "./movieClubs/movies/movieFunctions";
 import * as movieClubs from "./movieClubs/movieClubFunctions";
+import * as suggestions from "./movieClubs/suggestions/suggestionFunctions";
+// import * as movies from "./movieClubs/movies/movieFunctions";
 import * as users from "./users/userFunctions";
 
-export { comments, config, movies, movieClubs, users };
+export { comments, config, movieClubs, suggestions, users };

--- a/functions/src/movieClubs/movieClubFunctions.ts
+++ b/functions/src/movieClubs/movieClubFunctions.ts
@@ -48,7 +48,7 @@ exports.createMovieClub = functions.https.onCall(
 
       logVerbose("Movie Club created successfully!");
 
-      return movieClub;
+      return movieClub.id;
     } catch (error) {
       handleCatchHttpsError("Error creating Movie Club:", error);
     }

--- a/functions/src/movieClubs/suggestions/suggestionFunctions.ts
+++ b/functions/src/movieClubs/suggestions/suggestionFunctions.ts
@@ -41,7 +41,7 @@ exports.createMovieClubSuggestion = functions.https.onCall(
   }
 );
 
-exports.deleteMovieClubSuggestion = functions.https.onCall(
+exports.deleteUserMovieClubSuggestion = functions.https.onCall(
   async (request: CallableRequest<DeleteMovieClubSuggestionData>) => {
     try {
       const { data, auth } = request;

--- a/functions/src/movieClubs/suggestions/suggestionFunctions.ts
+++ b/functions/src/movieClubs/suggestions/suggestionFunctions.ts
@@ -1,0 +1,64 @@
+import * as functions from "firebase-functions";
+import { CallableRequest } from "firebase-functions/https";
+import { verifyMembership } from "src/users/userHelpers";
+import { CreateMovieClubSuggestionData, DeleteMovieClubSuggestionData } from "./suggestionTypes";
+import { getMovieClubSuggestionDocRef } from "./suggestionHelpers";
+
+import {
+  handleCatchHttpsError,
+  logVerbose,
+  verifyAuth,
+  verifyRequiredFields,
+} from "helpers";
+
+exports.createMovieClubSuggestion = functions.https.onCall(
+  async (request: CallableRequest<CreateMovieClubSuggestionData>) => {
+    try {
+      const { data, auth } = request;
+      const { uid } = verifyAuth(auth);
+
+      const requiredFields = ["imageUrl", "movieClubId", "title"];
+      verifyRequiredFields(data, requiredFields);
+      await verifyMembership(uid, data.movieClubId);
+
+      const suggestionRef = getMovieClubSuggestionDocRef(uid, data.movieClubId);
+
+      const suggestionData = {
+        uid: uid,
+        title: data.title,
+        imageUrl: data.imageUrl,
+        createdAt: Date.now()
+      };
+
+      await suggestionRef.set(suggestionData);
+
+      logVerbose("Suggestion created successfully!");
+
+      return;
+    } catch (error) {
+      handleCatchHttpsError("Error creating Suggestion:", error);
+    };
+  }
+);
+
+exports.deleteMovieClubSuggestion = functions.https.onCall(
+  async (request: CallableRequest<DeleteMovieClubSuggestionData>) => {
+    try {
+      const { data, auth } = request;
+      const { uid } = verifyAuth(auth);
+
+      const requiredFields = ["movieClubId"];
+      verifyRequiredFields(data, requiredFields);
+
+      const suggestionRef = getMovieClubSuggestionDocRef(uid, data.movieClubId);
+
+      await suggestionRef.delete();
+
+      logVerbose("Suggestion deleted successfully!");
+
+      return;
+    } catch (error) {
+      handleCatchHttpsError("Error deleting Suggestion:", error);
+    }
+  }
+);

--- a/functions/src/movieClubs/suggestions/suggestionFunctions.ts
+++ b/functions/src/movieClubs/suggestions/suggestionFunctions.ts
@@ -17,16 +17,16 @@ exports.createMovieClubSuggestion = functions.https.onCall(
       const { data, auth } = request;
       const { uid } = verifyAuth(auth);
 
-      const requiredFields = ["imageUrl", "movieClubId", "title"];
+      const requiredFields = ["imageUrl", "movieClubId", "title", "username"];
       verifyRequiredFields(data, requiredFields);
       await verifyMembership(uid, data.movieClubId);
 
       const suggestionRef = getMovieClubSuggestionDocRef(uid, data.movieClubId);
 
       const suggestionData = {
-        uid: uid,
         title: data.title,
         imageUrl: data.imageUrl,
+        username: data.username,
         createdAt: Date.now()
       };
 

--- a/functions/src/movieClubs/suggestions/suggestionHelpers.ts
+++ b/functions/src/movieClubs/suggestions/suggestionHelpers.ts
@@ -1,0 +1,13 @@
+import { firestore } from "firestore";
+import { MOVIE_CLUBS, SUGGESTIONS } from "src/utilities/collectionNames";
+
+export const getMovieClubSuggestionRef = (movieClubId: string) => {
+  return firestore
+    .collection(MOVIE_CLUBS)
+    .doc(movieClubId)
+    .collection(SUGGESTIONS)
+};
+
+export const getMovieClubSuggestionDocRef = (uid: string, movieClubId: string) => {
+  return getMovieClubSuggestionRef(movieClubId).doc(uid);
+};

--- a/functions/src/movieClubs/suggestions/suggestionTypes.ts
+++ b/functions/src/movieClubs/suggestions/suggestionTypes.ts
@@ -1,7 +1,8 @@
 export interface CreateMovieClubSuggestionData {
-  title: string;
-  movieClubId: string;
   imageUrl: string;
+  movieClubId: string;
+  title: string;
+  username: string;
 }
 
 export interface DeleteMovieClubSuggestionData {

--- a/functions/src/movieClubs/suggestions/suggestionTypes.ts
+++ b/functions/src/movieClubs/suggestions/suggestionTypes.ts
@@ -1,0 +1,9 @@
+export interface CreateMovieClubSuggestionData {
+  title: string;
+  movieClubId: string;
+  imageUrl: string;
+}
+
+export interface DeleteMovieClubSuggestionData {
+  movieClubId: string;
+}

--- a/functions/src/users/userFunctions.ts
+++ b/functions/src/users/userFunctions.ts
@@ -27,9 +27,9 @@ exports.createUserWithEmail = functions.https.onCall(
     try {
       const { data } = request;
       const requiredFields = ["email", "name", "password"];
-      verifyRequiredFields(request.data, requiredFields);
+      verifyRequiredFields(data, requiredFields);
 
-      const uid = await createUserAuthentication(request.data);
+      const uid = await createUserAuthentication(data);
       data.signInProvider = "password";
 
       if (uid) {
@@ -141,9 +141,7 @@ async function createUserAuthentication(
   }
 }
 
-type CreateUserData =
-  | (CreateUserWithEmailData & { signInProvider?: never })
-  | CreateUserWithOAuthData;
+type CreateUserData = CreateUserWithEmailData | CreateUserWithOAuthData;
 
 async function createUser(id: string, data: CreateUserData): Promise<void> {
   const userData = {

--- a/functions/src/users/userHelpers.ts
+++ b/functions/src/users/userHelpers.ts
@@ -1,0 +1,24 @@
+import { firestore } from "firestore";
+import { throwHttpsError } from "helpers";
+import { USERS, MEMBERSHIPS } from "src/utilities/collectionNames";
+
+export const verifyMembership = async (uid: string, movieClubId: string) => {
+  const membershipRef = firestore
+    .collection(USERS)
+    .doc(uid)
+    .collection(MEMBERSHIPS)
+    .doc(movieClubId);
+ try {
+   const membershipSnap = await membershipRef.get();
+   const membershipData = membershipSnap.data();
+   
+   if (membershipData === undefined) {
+     throwHttpsError(
+       "permission-denied",
+       "You are not a member of this Movie Club.",
+      );
+    };
+  } catch(error) {
+    throw error;
+  };
+} ;

--- a/functions/src/utilities/collectionNames.ts
+++ b/functions/src/utilities/collectionNames.ts
@@ -1,6 +1,7 @@
 export const USERS = "users";
 export const MEMBERSHIPS = "memberships";
 export const MOVIE_CLUBS = "movieclubs";
+export const SUGGESTIONS = "suggestions";
 export const MOVIES = "movies";
 export const MEMBERS = "members";
 export const COMMENTS = "comments";

--- a/functions/test/mocks/suggestion.ts
+++ b/functions/test/mocks/suggestion.ts
@@ -1,0 +1,35 @@
+import { logError, logVerbose } from "helpers";
+import { getMovieClubSuggestionDocRef } from "src/movieClubs/suggestions/suggestionHelpers";
+
+export interface SuggestionMock {
+  title: string;
+  imageUrl: string;
+  createdAt: number;
+}
+
+type SuggestionMockParams = Partial<SuggestionMock> & {
+  movieClubId: string;
+  userId: string;
+};
+
+export async function populateSuggestionData(
+  params: SuggestionMockParams,
+): Promise<SuggestionMock> {
+  logVerbose("Populating suggestion data...");
+
+  const suggestionData: SuggestionMock = {
+    imageUrl: params.imageUrl || "Test Image Url",
+    title: params.title || "Test Title",
+    createdAt: Date.now(),
+  };
+
+  const suggestionRef = getMovieClubSuggestionDocRef(params.userId, params.movieClubId)
+  try {
+    await suggestionRef.set(suggestionData);
+    logVerbose("suggestion data set");
+  } catch (error) {
+    logError("Error setting suggestion data:", error);
+  }
+
+  return suggestionData;
+}

--- a/functions/test/mocks/suggestion.ts
+++ b/functions/test/mocks/suggestion.ts
@@ -4,6 +4,7 @@ import { getMovieClubSuggestionDocRef } from "src/movieClubs/suggestions/suggest
 export interface SuggestionMock {
   title: string;
   imageUrl: string;
+  username: string;
   createdAt: number;
 }
 
@@ -20,6 +21,7 @@ export async function populateSuggestionData(
   const suggestionData: SuggestionMock = {
     imageUrl: params.imageUrl || "Test Image Url",
     title: params.title || "Test Title",
+    username: params.username || "Test Username",
     createdAt: Date.now(),
   };
 

--- a/functions/test/src/movieClubs/movieClubFunctions.test.ts
+++ b/functions/test/src/movieClubs/movieClubFunctions.test.ts
@@ -22,7 +22,6 @@ describe("createMovieClub", () => {
 
   let user: UserDataMock;
   let movieClubData: MovieClubData;
-  let movieClub: UpdateMovieClubData;
   let auth: AuthData;
 
   beforeEach(async () => {
@@ -47,10 +46,10 @@ describe("createMovieClub", () => {
   });
 
   it("should create a new Movie Club", async () => {
-    movieClub = await wrapped({ data: movieClubData, auth: auth });
+    const movieClubId = await wrapped({ data: movieClubData, auth: auth });
     const snap = await firestore
       .collection(MOVIE_CLUBS)
-      .doc(movieClub.id)
+      .doc(movieClubId)
       .get();
     const movieClubDoc = snap.data();
 

--- a/functions/test/src/movieClubs/suggestions/suggestionFunctions.test.ts
+++ b/functions/test/src/movieClubs/suggestions/suggestionFunctions.test.ts
@@ -13,7 +13,7 @@ import { populateSuggestionData } from "test/mocks/suggestion";
 // @ts-expect-error it works but ts won't detect it for some reason
 // TODO: Figure out why ts can't detect the export on this
 // prettier-ignore
-const { createMovieClubSuggestion, deleteMovieClubSuggestion } = suggestions;
+const { createMovieClubSuggestion, deleteUserMovieClubSuggestion } = suggestions;
 
 describe("Suggestion Functions", () => {
   let user: UserDataMock;
@@ -87,14 +87,14 @@ describe("Suggestion Functions", () => {
     });
   });
 
-  describe("deleteMovieClubSuggestion", () => {
-    const wrapped = firebaseTest.wrap(deleteMovieClubSuggestion);
+  describe("deleteUserMovieClubSuggestion", () => {
+    const wrapped = firebaseTest.wrap(deleteUserMovieClubSuggestion);
 
     beforeEach(async () => {
       await populateSuggestionData({ userId: user.id, movieClubId: movieClub.id, title: movieClubSuggestionData.title })
     });
 
-    it.only("should delete an existing suggestion", async () => {
+    it("should delete a suggestion for the requesting user", async () => {
       const snap = await getMovieClubSuggestionDocRef(user.id, movieClub.id).get();
       const movieClubSuggestionDoc = snap.data();
 

--- a/functions/test/src/movieClubs/suggestions/suggestionFunctions.test.ts
+++ b/functions/test/src/movieClubs/suggestions/suggestionFunctions.test.ts
@@ -34,9 +34,10 @@ describe("Suggestion Functions", () => {
     });
 
     movieClubSuggestionData = {
+      imageUrl: "Test Image Url",
       movieClubId: movieClub.id,
       title: "Test Movie Title",
-      imageUrl: "Test Image Url"
+      username: user.name
     }
   });
 
@@ -50,6 +51,7 @@ describe("Suggestion Functions", () => {
 
       assert.equal(movieClubSuggestionbDoc?.title, movieClubSuggestionData.title);
       assert.equal(movieClubSuggestionbDoc?.imageUrl, movieClubSuggestionData.imageUrl);
+      assert.equal(movieClubSuggestionbDoc?.username, movieClubSuggestionData.username);
     });
 
     it("should error if user is not a member of the club", async () => {

--- a/functions/test/src/movieClubs/suggestions/suggestionFunctions.test.ts
+++ b/functions/test/src/movieClubs/suggestions/suggestionFunctions.test.ts
@@ -1,0 +1,130 @@
+const assert = require("assert");
+import { firebaseTest } from "test/testHelper";
+import { suggestions } from "index";
+import { populateMovieClubData } from "mocks";
+import { populateUserData, UserDataMock } from "test/mocks/user";
+import { MovieClubMock } from "test/mocks/movieclub";
+import { AuthData } from "firebase-functions/tasks";
+import { CreateMovieClubSuggestionData } from "src/movieClubs/suggestions/suggestionTypes";
+import { getMovieClubSuggestionDocRef } from "src/movieClubs/suggestions/suggestionHelpers";
+import { populateMembershipData } from "test/mocks/membership";
+import { populateSuggestionData } from "test/mocks/suggestion";
+
+// @ts-expect-error it works but ts won't detect it for some reason
+// TODO: Figure out why ts can't detect the export on this
+// prettier-ignore
+const { createMovieClubSuggestion, deleteMovieClubSuggestion } = suggestions;
+
+describe("Suggestion Functions", () => {
+  let user: UserDataMock;
+  let movieClub: MovieClubMock;
+  let movieClubSuggestionData: CreateMovieClubSuggestionData;
+  let auth: AuthData;
+
+  beforeEach(async () => {
+    const userMock = await populateUserData();
+    user = userMock.user;
+    auth = userMock.auth;
+
+    movieClub = await populateMovieClubData({ ownerId: userMock.user.id });
+
+    await populateMembershipData({
+      userId: user.id,
+      movieClubId: movieClub.id,
+    });
+
+    movieClubSuggestionData = {
+      movieClubId: movieClub.id,
+      title: "Test Movie Title",
+      imageUrl: "Test Image Url"
+    }
+  });
+
+  describe("createMovieClubSuggestion", () => {
+    const wrapped = firebaseTest.wrap(createMovieClubSuggestion);
+
+    it("should create a new Movie Club Suggestion", async () => {
+      await wrapped({ data: movieClubSuggestionData, auth: auth });
+      const snap = await getMovieClubSuggestionDocRef(user.id, movieClub.id).get()
+      const movieClubSuggestionbDoc = snap.data();
+
+      assert.equal(movieClubSuggestionbDoc?.title, movieClubSuggestionData.title);
+      assert.equal(movieClubSuggestionbDoc?.imageUrl, movieClubSuggestionData.imageUrl);
+    });
+
+    it("should error if user is not a member of the club", async () => {
+      try {
+        auth.uid = "wrong-uid";
+        await wrapped({ data: movieClubSuggestionData, auth: auth });
+        assert.fail("Expected error not thrown");
+      } catch (error: any) {
+        assert.match(
+          error.message,
+          /You are not a member of this Movie Club./,
+        );
+      }
+    });
+
+    it("should error without required fields", async () => {
+      try {
+        await wrapped({ data: {}, auth: auth });
+        assert.fail("Expected error not thrown");
+      } catch (error: any) {
+        assert.match(
+          error.message,
+          /The function must be called with imageUrl, movieClubId, title./,
+        );
+      }
+    });
+
+    it("should error without auth", async () => {
+      try {
+        await wrapped({ data: {} });
+        assert.fail("Expected error not thrown");
+      } catch (error: any) {
+        assert.match(error.message, /auth object is undefined./);
+      }
+    });
+  });
+
+  describe("deleteMovieClubSuggestion", () => {
+    const wrapped = firebaseTest.wrap(deleteMovieClubSuggestion);
+
+    beforeEach(async () => {
+      await populateSuggestionData({ userId: user.id, movieClubId: movieClub.id, title: movieClubSuggestionData.title })
+    });
+
+    it.only("should delete an existing suggestion", async () => {
+      const snap = await getMovieClubSuggestionDocRef(user.id, movieClub.id).get();
+      const movieClubSuggestionDoc = snap.data();
+
+      assert.equal(movieClubSuggestionDoc?.imageUrl, movieClubSuggestionData.imageUrl);
+      assert.equal(movieClubSuggestionDoc?.title, movieClubSuggestionData.title);
+
+      await wrapped({ data: movieClubSuggestionData, auth: auth });
+
+      const deletedSnap = await getMovieClubSuggestionDocRef(user.id, movieClub.id).get();
+      const deletedMovieClubSuggestionDoc = deletedSnap.data();
+
+      assert.equal(deletedMovieClubSuggestionDoc, undefined)
+    });
+
+    it("should error without required fields", async () => {
+      try {
+        await wrapped({ data: {}, auth: auth });
+        assert.fail("Expected error not thrown");
+      } catch (error: any) {
+        assert.match(error.message, /The function must be called with movieClubId./);
+      }
+    });
+
+    it("should error without auth", async () => {
+      try {
+        await wrapped({ data: {} });
+        assert.fail("Expected error not thrown");
+      } catch (error: any) {
+        assert.match(error.message, /auth object is undefined./);
+      }
+    });
+  });
+});


### PR DESCRIPTION
closes #13 

Creates a `suggestions` subcollection under `movieclubs` with the fields:
```
{
  title: string,
  imageUrl: string,
  createdAt: number
}
```
Uses the `uid` for the suggestion's document id. If a user tries to create another suggestion, it will overwrite the old suggestion and will have an updated `createdAt` field. I figured client side checks to make sure they can't create a new suggestion if they already have one currently would be sufficient for the create route. 
This delete route will only delete the suggestion for the current requesting user. If we want a route for the owner to delete/deny a suggestion that will be a different route which I thought we would tackle in another card where the owner adds a movie to the queue.