### PR TITLE
User creation validation

### DIFF
--- a/MovieClub.xcodeproj/project.pbxproj
+++ b/MovieClub.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		2CDB72FB2D77878F004C0B2F /* Stolzl-Regular.otf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2CDB72ED2D77860E004C0B2F /* Stolzl-Regular.otf */; };
 		2CDB72FC2D77878F004C0B2F /* Stolzl-Thin.otf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2CDB72EE2D77860E004C0B2F /* Stolzl-Thin.otf */; };
 		2CDB72FE2D778DA7004C0B2F /* FontExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDB72FD2D778D9F004C0B2F /* FontExtensions.swift */; };
+		2CDB73002D782FBA004C0B2F /* UserValidationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDB72FF2D782FBA004C0B2F /* UserValidationService.swift */; };
 		2CE0C97D2D5AC5A600ECC962 /* MovieClubCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE0C97C2D5AC5A600ECC962 /* MovieClubCardView.swift */; };
 		2CE0C97F2D5ACD0100ECC962 /* CachedAsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE0C97E2D5ACD0100ECC962 /* CachedAsyncImage.swift */; };
 		2CE0C9812D5B0BE700ECC962 /* CommentsSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CE0C9802D5B0BE700ECC962 /* CommentsSheetView.swift */; };
@@ -235,6 +236,7 @@
 		2CDB72ED2D77860E004C0B2F /* Stolzl-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Stolzl-Regular.otf"; sourceTree = "<group>"; };
 		2CDB72EE2D77860E004C0B2F /* Stolzl-Thin.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Stolzl-Thin.otf"; sourceTree = "<group>"; };
 		2CDB72FD2D778D9F004C0B2F /* FontExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontExtensions.swift; sourceTree = "<group>"; };
+		2CDB72FF2D782FBA004C0B2F /* UserValidationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserValidationService.swift; sourceTree = "<group>"; };
 		2CE0C97C2D5AC5A600ECC962 /* MovieClubCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieClubCardView.swift; sourceTree = "<group>"; };
 		2CE0C97E2D5ACD0100ECC962 /* CachedAsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachedAsyncImage.swift; sourceTree = "<group>"; };
 		2CE0C9802D5B0BE700ECC962 /* CommentsSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentsSheetView.swift; sourceTree = "<group>"; };
@@ -355,6 +357,7 @@
 		2C11FFF42CA37FC1004F54BC /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				2CDB72FF2D782FBA004C0B2F /* UserValidationService.swift */,
 				2CF7AF632D4152C4006A8EBD /* Auth */,
 				2CF7AF622D4152BD006A8EBD /* Notifications */,
 				2CD39CE92D2A32D7003D6398 /* APIController.swift */,
@@ -930,6 +933,7 @@
 				2C44751B2C4C63AB0034204C /* NowShowingView.swift in Sources */,
 				2CD39CEA2D2A32D7003D6398 /* APIController.swift in Sources */,
 				2CF7B28A2D4EE296006A8EBD /* MainTabView.swift in Sources */,
+				2CDB73002D782FBA004C0B2F /* UserValidationService.swift in Sources */,
 				2C1326BE2CCACF820076E39C /* ArchivesView.swift in Sources */,
 				2C8256BD2BF1E63800D2ED12 /* NewClubView.swift in Sources */,
 				2C8256BB2BF1BC9300D2ED12 /* LoginView.swift in Sources */,

--- a/MovieClub/Util/UserValidationService.swift
+++ b/MovieClub/Util/UserValidationService.swift
@@ -67,7 +67,7 @@ struct UserValidationService {
             return .failure(.passwordEmpty)
         }
         
-        if password.count < 8 {
+        if password.count < 6 {
             return .failure(.passwordTooShort)
         }
         
@@ -167,13 +167,13 @@ struct ValidatedTextField: View {
                 
                 if isSecure {
                     SecureField(title, text: $text)
-                        .onChange(of: text) { _, newValue in
-                            validateText(newValue)
+                        .onChange(of: text) {
+                            validateText(text)
                         }
                 } else {
                     TextField(title, text: $text)
-                        .onChange(of: text) { _, newValue in
-                            validateText(newValue)
+                        .onChange(of: text) {
+                            validateText(text)
                         }
                 }
             }

--- a/MovieClub/Util/UserValidationService.swift
+++ b/MovieClub/Util/UserValidationService.swift
@@ -1,0 +1,291 @@
+import Foundation
+import SwiftUI
+
+struct UserValidationService {
+    // Validation errors for user input
+    enum ValidationError: LocalizedError, Identifiable {
+        var id: String { errorDescription ?? UUID().uuidString }
+        
+        case emailEmpty
+        case emailInvalid
+        case passwordEmpty
+        case passwordTooShort
+        case passwordTooWeak
+        case passwordsDoNotMatch
+        case nameEmpty
+        case nameTooShort
+        case nameTooLong
+        case nameContainsProfanity
+        
+        var errorDescription: String? {
+            switch self {
+            case .emailEmpty:
+                return "Email cannot be empty"
+            case .emailInvalid:
+                return "Please enter a valid email address"
+            case .passwordEmpty:
+                return "Password cannot be empty"
+            case .passwordTooShort:
+                return "Password must be at least 8 characters"
+            case .passwordTooWeak:
+                return "Password must contain at least one uppercase letter, one number, and one special character"
+            case .passwordsDoNotMatch:
+                return "Passwords do not match"
+            case .nameEmpty:
+                return "Name cannot be empty"
+            case .nameTooShort:
+                return "Name must be at least 2 characters"
+            case .nameTooLong:
+                return "Name cannot be longer than 50 characters"
+            case .nameContainsProfanity:
+                return "Name contains inappropriate content"
+            }
+        }
+    }
+    
+    // Validate email
+    static func validateEmail(_ email: String) -> Result<Void, ValidationError> {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if trimmedEmail.isEmpty {
+            return .failure(.emailEmpty)
+        }
+        
+        let emailRegex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"
+        let emailPredicate = NSPredicate(format: "SELF MATCHES %@", emailRegex)
+        
+        if !emailPredicate.evaluate(with: trimmedEmail) {
+            return .failure(.emailInvalid)
+        }
+        
+        return .success(())
+    }
+    
+    // Validate password
+    static func validatePassword(_ password: String) -> Result<Void, ValidationError> {
+        if password.isEmpty {
+            return .failure(.passwordEmpty)
+        }
+        
+        if password.count < 8 {
+            return .failure(.passwordTooShort)
+        }
+        
+        // Check for at least one uppercase letter
+        let uppercaseRegex = ".*[A-Z]+.*"
+        let uppercasePredicate = NSPredicate(format: "SELF MATCHES %@", uppercaseRegex)
+        
+        // Check for at least one number
+        let numberRegex = ".*[0-9]+.*"
+        let numberPredicate = NSPredicate(format: "SELF MATCHES %@", numberRegex)
+        
+        // Check for at least one special character
+        let specialCharRegex = ".*[!@#$%^&*()_\\-+=\\[\\]{}|:;\"'<>,.?/~`]+.*"
+        let specialCharPredicate = NSPredicate(format: "SELF MATCHES %@", specialCharRegex)
+        
+        // For a strong password, require at least two of the three criteria
+        let criteriaCount = [
+            uppercasePredicate.evaluate(with: password),
+            numberPredicate.evaluate(with: password),
+            specialCharPredicate.evaluate(with: password)
+        ].filter { $0 }.count
+        
+        if criteriaCount < 2 {
+            return .failure(.passwordTooWeak)
+        }
+        
+        return .success(())
+    }
+    
+    // Validate password confirmation
+    static func validatePasswordConfirmation(password: String, confirmation: String) -> Result<Void, ValidationError> {
+        if password != confirmation {
+            return .failure(.passwordsDoNotMatch)
+        }
+        
+        return .success(())
+    }
+    
+    // Validate name
+    static func validateName(_ name: String) -> Result<Void, ValidationError> {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if trimmedName.isEmpty {
+            return .failure(.nameEmpty)
+        }
+        
+        if trimmedName.count < 2 {
+            return .failure(.nameTooShort)
+        }
+        
+        if trimmedName.count > 50 {
+            return .failure(.nameTooLong)
+        }
+        
+        // Use existing profanity check from ValidationService
+        if ValidationService.containsProfanity(trimmedName) {
+            return .failure(.nameContainsProfanity)
+        }
+        
+        return .success(())
+    }
+}
+
+// MARK: - UI Components for validation
+
+struct ValidatedTextField: View {
+    let title: String
+    @Binding var text: String
+    @Binding var error: String?
+    let validate: (String) -> Result<Void, UserValidationService.ValidationError>
+    let isSecure: Bool
+    let icon: String?
+    
+    init(
+        title: String,
+        text: Binding<String>,
+        error: Binding<String?>,
+        validate: @escaping (String) -> Result<Void, UserValidationService.ValidationError>,
+        isSecure: Bool = false,
+        icon: String? = nil
+    ) {
+        self.title = title
+        self._text = text
+        self._error = error
+        self.validate = validate
+        self.isSecure = isSecure
+        self.icon = icon
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                if let icon = icon {
+                    Image(systemName: icon)
+                        .foregroundColor(error == nil ? .gray : .red)
+                }
+                
+                if isSecure {
+                    SecureField(title, text: $text)
+                        .onChange(of: text) { _, newValue in
+                            validateText(newValue)
+                        }
+                } else {
+                    TextField(title, text: $text)
+                        .onChange(of: text) { _, newValue in
+                            validateText(newValue)
+                        }
+                }
+            }
+            .padding()
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.1))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(error == nil ? Color.clear : Color.red, lineWidth: 1)
+                    )
+            )
+            
+            if let error = error {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.red)
+                        .font(.caption)
+                    
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+                .padding(.horizontal, 4)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+    }
+    
+    private func validateText(_ text: String) {
+        let result = validate(text)
+        
+        withAnimation {
+            switch result {
+            case .success:
+                error = nil
+            case .failure(let validationError):
+                error = validationError.errorDescription
+            }
+        }
+    }
+}
+
+struct PrimaryButton: View {
+    let title: String
+    let action: () -> Void
+    let isDisabled: Bool
+    let isLoading: Bool
+    
+    init(
+        title: String,
+        action: @escaping () -> Void,
+        isDisabled: Bool = false,
+        isLoading: Bool = false
+    ) {
+        self.title = title
+        self.action = action
+        self.isDisabled = isDisabled
+        self.isLoading = isLoading
+    }
+    
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .padding(.trailing, 5)
+                }
+                
+                Text(title)
+                    .foregroundColor(.white)
+                    .fontWeight(.medium)
+            }
+            .frame(minWidth: 200, minHeight: 50)
+            .background(isDisabled ? Color.gray : Color.blue)
+            .cornerRadius(8)
+            .contentShape(Rectangle())
+        }
+        .disabled(isDisabled || isLoading)
+    }
+}
+
+struct FormErrorBanner: View {
+    let error: Error?
+    let dismiss: () -> Void
+    
+    var body: some View {
+        if let error = error {
+            VStack {
+                HStack {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .foregroundColor(.white)
+                    
+                    Text(error.localizedDescription)
+                        .foregroundColor(.white)
+                    
+                    Spacer()
+                    
+                    Button(action: dismiss) {
+                        Image(systemName: "xmark")
+                            .foregroundColor(.white)
+                    }
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.red)
+                )
+                .padding(.horizontal)
+            }
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
+    }
+} 

--- a/MovieClub/Views/Clubs/ClubDetailView.swift
+++ b/MovieClub/Views/Clubs/ClubDetailView.swift
@@ -22,7 +22,7 @@ struct ClubDetailView: View {
                     .tag(0)
         
                 NowShowingView()
-                        .tag(1)
+                    .tag(1)
                 
                 ComingSoonView(startDate: club.movieEndDate, timeInterval: club.timeInterval)
                     .tag(2)

--- a/MovieClub/Views/Clubs/CommentViews/CommentInputView.swift
+++ b/MovieClub/Views/Clubs/CommentViews/CommentInputView.swift
@@ -79,7 +79,7 @@ struct CommentInputView: View {
                 .padding(.horizontal, 5)
             }
             
-            HStack(alignment: .center, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
                 VStack(alignment: .leading, spacing: 4) {
                     TextField(textLabel, text: $commentText, axis: .vertical)
                         .padding(10)
@@ -132,6 +132,8 @@ struct CommentInputView: View {
                     }
                     .frame(width: 30, height: 30)
                 }
+                .padding(.top, 4)
+                
                 .foregroundStyle(
                     isCommentValid 
                     ? LinearGradient(colors: [.blue, .purple], startPoint: .topLeading, endPoint: .bottomTrailing)
@@ -203,12 +205,10 @@ struct CommentInputView: View {
             isFocused = false
             onCommentPosted() // Call the callback after successful comment post
             
-            // Reset button after delay
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                withAnimation {
-                    showCheckmark = false
-                }
+            withAnimation {
+                showCheckmark = false
             }
+            
             
         } catch {
             isSubmitting = false

--- a/MovieClub/Views/Clubs/NowShowing/FeaturedMovieView.swift
+++ b/MovieClub/Views/Clubs/NowShowing/FeaturedMovieView.swift
@@ -96,7 +96,6 @@ struct FeaturedMovieView: View {
                     
                     // Plot
                     Text(movie.plot)
-                        .font(.callout)
                         .lineLimit(4)
                         .truncationMode(.tail)
                         .foregroundColor(.white)

--- a/MovieClub/Views/Tabs/HomePageView.swift
+++ b/MovieClub/Views/Tabs/HomePageView.swift
@@ -41,9 +41,14 @@ struct HomePageView: View {
             } else {
                 // Original layout without extra padding/spacing changes
                 if userClubs.isEmpty {
-                    VStack {
+                    VStack(spacing: 8) {
                         Spacer()
-                        Text("No clubs Found")
+                        
+                        Text("No Clubs Found")
+                            .font(.title)
+                            .fontWeight(.semibold)
+                        Text("Create or Join ne to get started")
+                            .font(.caption)
                         Spacer()
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/MovieClub/Views/User/LoginView.swift
+++ b/MovieClub/Views/User/LoginView.swift
@@ -53,19 +53,24 @@ struct LoginView: View {
                     )
                     .padding(.horizontal, 50)
                     .padding(.bottom, 20)
-                    
-                    // Password field with validation
-                    ValidatedTextField(
-                        title: "Password",
-                        text: $userPwd,
-                        error: $passwordError,
-                        validate: UserValidationService.validatePassword,
-                        isSecure: true,
-                        icon: "lock"
+                    HStack {
+                        Image(systemName: "lock")
+                            .foregroundStyle(.gray)
+                        SecureField("Password", text: $userPwd)
+                           
+                            
+                    }
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.gray.opacity(0.1))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(error == nil ? Color.clear : Color.red, lineWidth: 1)
+                            )
                     )
                     .padding(.horizontal, 50)
-                    .padding(.bottom, 50)
-                    
+                    .padding(.bottom, 20)
                     // Sign in button
                     PrimaryButton(
                         title: "Sign In",
@@ -123,7 +128,7 @@ struct LoginView: View {
         
         switch passwordValidation {
         case .success: passwordError = nil
-        case .failure(let validationError): passwordError = validationError.errorDescription
+        case .failure(let validationError): passwordError = nil
         }
         
         // Don't proceed if validation failed

--- a/MovieClub/Views/User/LoginView.swift
+++ b/MovieClub/Views/User/LoginView.swift
@@ -14,90 +14,137 @@ struct LoginView: View {
     
     @Environment(DataManager.self) private var data
     @Environment(\.dismiss) private var dismiss
-    @State var error: Error? = nil
-    @State var errorShowing: Bool = false
+    
+    // State variables
     @State private var userEmail = ""
     @State private var userPwd = ""
-    private var btnDisabled: Bool {
-        if userEmail.isEmpty || userPwd.isEmpty {
-            return true
-        }else{
-            return false
-        }
+    @State private var error: Error? = nil
+    @State private var isLoading = false
+    
+    // Validation error states
+    @State private var emailError: String? = nil
+    @State private var passwordError: String? = nil
+    
+    private var isFormValid: Bool {
+        return emailError == nil && 
+               passwordError == nil && 
+               !userEmail.isEmpty && 
+               !userPwd.isEmpty
     }
     
     var body: some View {
-        NavigationStack{
-            VStack {
-                Spacer()
-                Text("Movie Club")
-                    .font(.title)
-                    .fontWeight(.bold)
-                    .fontDesign(.rounded)
-                    .padding(.bottom, 50)
-                
-                TextField("Email", text: $userEmail)
-                    .padding()
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
+        NavigationStack {
+            ZStack {
+                VStack {
+                    Spacer()
+                    Text("Movie Club")
+                        .font(.title)
+                        .fontWeight(.bold)
+                        .fontDesign(.rounded)
+                        .padding(.bottom, 50)
+                    
+                    // Email field with validation
+                    ValidatedTextField(
+                        title: "Email",
+                        text: $userEmail,
+                        error: $emailError,
+                        validate: UserValidationService.validateEmail,
+                        icon: "envelope"
+                    )
                     .padding(.horizontal, 50)
                     .padding(.bottom, 20)
-                
-                SecureField("Password", text: $userPwd)
-                    .padding()
-                    .background(Color.gray.opacity(0.1))
-                    .cornerRadius(8)
+                    
+                    // Password field with validation
+                    ValidatedTextField(
+                        title: "Password",
+                        text: $userPwd,
+                        error: $passwordError,
+                        validate: UserValidationService.validatePassword,
+                        isSecure: true,
+                        icon: "lock"
+                    )
                     .padding(.horizontal, 50)
                     .padding(.bottom, 50)
-                
-                Button {
-                    Task{
-                        try await handleSignIn()
+                    
+                    // Sign in button
+                    PrimaryButton(
+                        title: "Sign In",
+                        action: {
+                            Task {
+                                await handleSignIn()
+                            }
+                        },
+                        isDisabled: !isFormValid,
+                        isLoading: isLoading
+                    )
+                    
+                    Spacer()
+                    
+                    // Sign up link
+                    NavigationLink {
+                        SignUpView()
+                            .navigationBarBackButtonHidden(true)
+                    } label: {
+                        HStack(spacing: 3) {
+                            Text("Don't have an account?")
+                            Text("Sign Up!")
+                                .fontWeight(.bold)
+                        }
+                        .foregroundStyle(.blue)
+                        .font(.body)
                     }
-                } label: {
-                    Text("Sign In")
-                        .foregroundColor(.white)
-                        .frame(width: 200, height: 50)
-                        .background(btnDisabled ? Color.gray : Color.blue)
-                        .cornerRadius(8)
                 }
-                .disabled(btnDisabled)
-                Spacer()
-                NavigationLink {
-                    SignUpView()
-                        .navigationBarBackButtonHidden(true)
-                } label: {
-                    HStack(spacing: 3){
-                        Text("Don't have an account?")
-                        Text("Sign Up!")
-                            .fontWeight(.bold)
+                
+                // Error banner that slides in from the top
+                VStack {
+                    FormErrorBanner(error: error) {
+                        withAnimation {
+                            error = nil
+                        }
                     }
-                    .foregroundStyle(.blue)
-                    .font(.body)
+                    .padding(.top)
+                    
+                    Spacer()
                 }
             }
         }
-        .alert("Error", isPresented: .constant(error != nil), actions: {
-            Button("OK") {
-                error = nil
-            }
-        }, message: {
-            if let error = error {
-                Text(error.localizedDescription)
-            }
-        })
     }
     
-    func handleSignIn() async throws {
-        if userEmail.isEmpty || userPwd.isEmpty {
-            error = "Please enter an email and password." as? any Error
+    func handleSignIn() async {
+        // Validate fields first
+        let emailValidation = UserValidationService.validateEmail(userEmail)
+        let passwordValidation = UserValidationService.validatePassword(userPwd)
+        
+        // Update validation errors
+        switch emailValidation {
+        case .success: emailError = nil
+        case .failure(let validationError): emailError = validationError.errorDescription
+        }
+        
+        switch passwordValidation {
+        case .success: passwordError = nil
+        case .failure(let validationError): passwordError = validationError.errorDescription
+        }
+        
+        // Don't proceed if validation failed
+        if emailError != nil || passwordError != nil {
             return
         }
-        print("Signing in...")
+        
+        // Show loading state
+        isLoading = true
+        
         do {
             try await data.signIn(email: userEmail, password: userPwd)
+            // Success - dismiss will happen automatically since auth state changes
         } catch {
-            self.error = error
+            // Show error with animation
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
+                self.error = error
+            }
         }
+        
+        // Hide loading state
+        isLoading = false
     }
 }


### PR DESCRIPTION
This pull request introduces a new `UserValidationService` and updates the `LoginView` to use this service for input validation. Additionally, it includes minor UI adjustments and refactoring in various views.

### New Features:
* **User Validation Service:**
  * Added `UserValidationService.swift` to handle user input validation, including email, password, and name validations. This service includes error handling and localized error messages.

### Updates to Existing Views:
* **LoginView:**
  * Integrated `ValidatedTextField` for email input with validation.
  * Added `PrimaryButton` for the sign-in action with loading and disabled states.
  * Implemented form validation logic and error handling using `UserValidationService`.
  * Updated UI to include error banners for displaying validation errors. [[1]](diffhunk://#diff-08ba67d5757701d6c6f76d504e2ddebec02e268981365015d27ab74bc828bd78L17-R37) [[2]](diffhunk://#diff-08ba67d5757701d6c6f76d504e2ddebec02e268981365015d27ab74bc828bd78L39-R88) [[3]](diffhunk://#diff-08ba67d5757701d6c6f76d504e2ddebec02e268981365015d27ab74bc828bd78L79-R154)

### Minor UI Adjustments:
* **CommentInputView:**
  * Adjusted alignment and padding for better visual consistency. [[1]](diffhunk://#diff-08896621596de4dd67e15c29f8167f28d08bccbef358cad540ed4dd2e62ca72dL82-R82) [[2]](diffhunk://#diff-08896621596de4dd67e15c29f8167f28d08bccbef358cad540ed4dd2e62ca72dR135-R136) [[3]](diffhunk://#diff-08896621596de4dd67e15c29f8167f28d08bccbef358cad540ed4dd2e62ca72dL206-R211)
* **FeaturedMovieView:**
  * Removed redundant font specification for the plot text.
* **HomePageView:**
  * Improved layout and typography for empty state messages.

### Project Configuration:
* **Xcode Project:**
  * Added `UserValidationService.swift` to the project file references and build phases. [[1]](diffhunk://#diff-a8182ee77e11b061f7cc0f295b76d9ddf253eb4126e431aa2e7949c382c1e58cR106) [[2]](diffhunk://#diff-a8182ee77e11b061f7cc0f295b76d9ddf253eb4126e431aa2e7949c382c1e58cR239) [[3]](diffhunk://#diff-a8182ee77e11b061f7cc0f295b76d9ddf253eb4126e431aa2e7949c382c1e58cR360) [[4]](diffhunk://#diff-a8182ee77e11b061f7cc0f295b76d9ddf253eb4126e431aa2e7949c382c1e58cR936)