### PR TITLE
Update movie rotation logic to handle Firestore Timestamps

### DIFF
--- a/MovieClub/Views/Clubs/NowShowing/NowShowingView.swift
+++ b/MovieClub/Views/Clubs/NowShowing/NowShowingView.swift
@@ -33,6 +33,14 @@ struct NowShowingView: View {
         return elapsedDuration / totalDuration
     }
     
+    // Format date to show correct day regardless of time zone
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter.string(from: date).uppercased()
+    }
+    
     // MARK: - Body
     var body: some View {
         VStack {
@@ -186,7 +194,8 @@ struct NowShowingView: View {
     
     private var progressBar: some View {
         HStack {
-            Text(movie?.startDate ?? Date(), format: .dateTime.day().month())
+            let _ = print("startDate: \(movie?.startDate)")
+            Text(movie?.startDate != nil ? formatDate(movie!.startDate) : "")
                 .font(.title3)
                 .textCase(.uppercase)
             
@@ -194,7 +203,7 @@ struct NowShowingView: View {
                 .progressViewStyle(ClubProgressViewStyle())
                 .frame(height: 10)
             
-            Text(movie?.endDate ?? Date(), format: .dateTime.day().month())
+            Text(movie?.endDate != nil ? formatDate(movie!.endDate) : "")
                 .font(.title3)
                 .textCase(.uppercase)
         }

--- a/MovieClub/Views/Clubs/NowShowing/NowShowingView.swift
+++ b/MovieClub/Views/Clubs/NowShowing/NowShowingView.swift
@@ -194,7 +194,6 @@ struct NowShowingView: View {
     
     private var progressBar: some View {
         HStack {
-            let _ = print("startDate: \(movie?.startDate)")
             Text(movie?.startDate != nil ? formatDate(movie!.startDate) : "")
                 .font(.title3)
                 .textCase(.uppercase)

--- a/functions/src/movieClubs/movies/movieTypes.ts
+++ b/functions/src/movieClubs/movies/movieTypes.ts
@@ -1,10 +1,12 @@
+import { Timestamp } from 'firebase-admin/firestore';
+
 export interface MovieData {
   likes: number;
   dislikes: number;
   numCollected: number;
   status: "active" | "archived";
-  startDate: Date;
-  endDate: Date;
+  startDate: Date | Timestamp;
+  endDate: Date | Timestamp;
   numComments: number;
   imdbId: string;
   collectedBy: string[];


### PR DESCRIPTION
This pull request includes several updates to the `movieFunctions.ts` file to handle `Timestamp` objects from Firestore more consistently. The changes involve converting `Date` objects to `Timestamp` objects for storage and comparison purposes. The most important changes include updates to the `rotateMovie` function and the `MovieData` interface.

Updates to `rotateMovie` function:

* Converted `endDate` and `startDate` fields from `Date` to Firestore `Timestamp` for consistent storage and comparison. [[1]](diffhunk://#diff-ea2a36f6959344a5114166128fd368ddd21423af849a58768557c14a3d66c26eL45-R46) [[2]](diffhunk://#diff-ea2a36f6959344a5114166128fd368ddd21423af849a58768557c14a3d66c26eL63-R69) [[3]](diffhunk://#diff-ea2a36f6959344a5114166128fd368ddd21423af849a58768557c14a3d66c26eL73-R85) [[4]](diffhunk://#diff-ea2a36f6959344a5114166128fd368ddd21423af849a58768557c14a3d66c26eL90-R107) [[5]](diffhunk://#diff-ea2a36f6959344a5114166128fd368ddd21423af849a58768557c14a3d66c26eL119-R159) [[6]](diffhunk://#diff-ea2a36f6959344a5114166128fd368ddd21423af849a58768557c14a3d66c26eL136-R169) [[7]](diffhunk://#diff-ea2a36f6959344a5114166128fd368ddd21423af849a58768557c14a3d66c26eL149-R182)
* Added logic to set the start date to the day after the previous movie ends if there was an active movie, or to 12:00 AM today if there was no active movie.

Updates to `MovieData` interface:

* Modified the `MovieData` interface to allow `startDate` and `endDate` fields to be either `Date` or Firestore `Timestamp`.